### PR TITLE
Upper bound to base to 4.9

### DIFF
--- a/ghc-heap-view.cabal
+++ b/ghc-heap-view.cabal
@@ -64,7 +64,7 @@ Library
     GHC.Disassembler
     GHC.HeapView.Debug
   Build-depends:
-    base >= 4.5 && < 4.8,
+    base >= 4.5 && < 4.9,
     containers,
     transformers,
     template-haskell,


### PR DESCRIPTION
As with the discussion under #4 

Here you can see the log of my local install, that the tests have been run and it works in the  REPL https://gist.github.com/mhitza/8e4826a712f637bfb7de

Missing from the log are the tab warnings that ghc 7.10.1 issues, since I've disabled them prior with -fno-warn-tab

I could make/test the changes to remove the warnings that ghc issues (some might be errors not covered by the test like unsafePerformIO) however I'm not sure how you'd want to approach backwards compatibility in this case.

A question still, why can't the library be built with profiling enabled?