### PR TITLE
Accept ghc-8.4.3/Cabal-2.5/base-4.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@
 env:
  - CABALVER=1.24 GHCVER=8.0.2
  - CABALVER=2.0 GHCVER=8.2.1
+ - CABALVER=2.4 GHCVER=8.4.3
  - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 matrix:

--- a/ghc-heap-view.cabal
+++ b/ghc-heap-view.cabal
@@ -1,5 +1,5 @@
 Name:                ghc-heap-view
-Version:             0.5.10
+Version:             0.5.11
 Synopsis:            Extract the heap representation of Haskell values and thunks
 Description:
   This library provides functions to introspect the Haskell heap, for example
@@ -63,7 +63,7 @@ Flag ghc_8_2
 custom-setup
   setup-depends: base
   setup-depends: filepath
-  setup-depends: Cabal >= 1.24 && < 2.1
+  setup-depends: Cabal >= 1.24 && < 2.6
 
 Library
   Default-Language:    Haskell2010
@@ -73,7 +73,7 @@ Library
     GHC.Disassembler
     GHC.HeapView.Debug
   Build-depends:
-    base >= 4.5 && < 4.11,
+    base >= 4.5 && < 4.13,
     containers,
     transformers,
     template-haskell,
@@ -86,7 +86,7 @@ Library
     cpp-options: -DGHC_8_0
   else
     if flag(ghc_8_2)
-      build-depends: ghc >= 8.2 && < 8.4
+      build-depends: ghc >= 8.2 && < 8.6
       cc-options: -DGHC_8_2
       cpp-options: -DGHC_8_2
     else


### PR DESCRIPTION
```
$ cabal -w/opt/ghc/bin/ghc-8.4.3 new-test
Resolving dependencies...
Build profile: -w ghc-8.4.3 -O1
In order, the following will be built (use -v for more details):
 - ghc-heap-view-0.5.11 (configuration changed)
Warning: ghc-heap-view.cabal:69:3: The field "default-language" is specified
more than once at positions 69:3, 99:3
Configuring ghc-heap-view-0.5.11...
Preprocessing library for ghc-heap-view-0.5.11..
Building library for ghc-heap-view-0.5.11..
Preprocessing test suite 'Test' for ghc-heap-view-0.5.11..
Building test suite 'Test' for ghc-heap-view-0.5.11..
Warning: /tmp/ghc-heap-view/ghc-heap-view.cabal:69:3: The field
"default-language" is specified more than once at positions 69:3, 99:3
Running 1 test suites...
Test suite Test: RUNNING...
Test suite Test: PASS
Test suite logged to:
/tmp/ghc-heap-view/dist-newstyle/build/x86_64-linux/ghc-8.4.3/ghc-heap-view-0.5.11/test/ghc-heap-view-0.5.11-Test.log
1 of 1 test suites (1 of 1 test cases) passed.
$ cabal --version
cabal-install version 2.5.0.0
compiled using version 2.5.0.0 of the Cabal library
```
