### PR TITLE
Support GHC 8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 # lines listings versions you don't need/want testing for.
 env:
  - CABALVER=2.4 GHCVER=8.6.3
+ - CABALVER=2.4 GHCVER=8.8.1
  - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 matrix:

--- a/Test.hs
+++ b/Test.hs
@@ -5,7 +5,6 @@ import GHC.HeapView
 
 import Control.DeepSeq
 import Control.Monad
-import Control.Applicative (pure)
 
 import System.Environment
 import System.Mem

--- a/ghc-heap-view.cabal
+++ b/ghc-heap-view.cabal
@@ -1,11 +1,12 @@
 Name:                ghc-heap-view
-Version:             0.6.0
+Version:             0.6.1
 Synopsis:            Extract the heap representation of Haskell values and thunks
 Description:
   This library provides functions to introspect the Haskell heap, for example
   to investigate sharing and lazy evaluation. As this is tied to the internals
   of the compiler, it only works with specific versions. This version supports,
-  GHC 8.6. For older GHC versions see ghc-heap-view-0.5.10.
+  GHC 8.8. For GHC 8.6 use version 0.6.0. For older GHC versions see
+  ghc-heap-view-0.5.10.
   .
   It has been inspired by (and taken code from) the vacuum package and the GHCi
   debugger, but also allows to investigate thunks and other closures.
@@ -40,7 +41,7 @@ Description:
   .
   The work on this package has been supported by the Deutsche Telekom Stiftung
   (<http://telekom-stiftung.de>).
-tested-with: GHC == 8.6.1, GHC == 8.6.2, GHC == 8.6.3, GHC == 8.6.4, GHC == 8.6.5
+tested-with: GHC == 8.6.1, GHC == 8.6.2, GHC == 8.6.3, GHC == 8.6.4, GHC == 8.6.5, GHC == 8.8.1
 License:             BSD3
 License-file:        LICENSE
 Author:              Joachim Breitner, Dennis Felsing
@@ -60,7 +61,7 @@ Flag prim-supports-any
 custom-setup
   setup-depends: base
   setup-depends: filepath
-  setup-depends: Cabal >= 1.24 && < 2.6
+  setup-depends: Cabal >= 1.24 && < 3.2
 
 Library
   Default-Language:    Haskell2010
@@ -70,7 +71,7 @@ Library
     GHC.Disassembler
     GHC.HeapView.Debug
   Build-depends:
-    base >= 4.12 && < 4.13,
+    base >= 4.12 && < 4.14,
     ghc-heap,
     containers,
     transformers,

--- a/src/GHC/AssertNF.hs
+++ b/src/GHC/AssertNF.hs
@@ -31,7 +31,6 @@ import Text.Printf
 import Language.Haskell.TH (Q, Exp(AppE,VarE,LitE), Lit(StringL), Loc, location, loc_filename, loc_start, mkName)
 import Data.IORef
 import System.IO.Unsafe ( unsafePerformIO )
-import Control.Applicative ((<$>))
 
 enabledRef :: IORef Bool
 enabledRef = unsafePerformIO $ newIORef True

--- a/src/GHC/Disassembler.hs
+++ b/src/GHC/Disassembler.hs
@@ -13,9 +13,6 @@ import Data.Binary.Get
 import Data.Word
 import Data.Int
 import Data.Bits
-import Data.Foldable    ( Foldable )
-import Data.Traversable ( Traversable )
-import Control.Applicative ((<$>))
 
 #include "ghcautoconf.h"
 #include "rts/Bytecodes.h"

--- a/src/GHC/HeapView.hs
+++ b/src/GHC/HeapView.hs
@@ -65,12 +65,9 @@ import Foreign          hiding ( void )
 import Data.Char
 import Data.List
 import Data.Maybe       ( catMaybes )
-import Data.Monoid      ( Monoid, (<>), mempty )
 import Data.Functor
 import Data.Function
-import Data.Foldable    ( Foldable )
 import qualified Data.Foldable as F
-import Data.Traversable ( Traversable )
 import qualified Data.Traversable as T
 import qualified Data.IntMap as M
 import Control.Monad
@@ -84,11 +81,13 @@ import GHC.Disassembler
 
 #include "ghcautoconf.h"
 
+#if __GLASGOW_HASKELL__ == 806
 -- Deriving for Functor, Foldable and Traversable is missing in  GHC 8.6
 -- will be available in GHC 8.8
 deriving instance Functor GenClosure
 deriving instance Foldable GenClosure
 deriving instance Traversable GenClosure
+#endif
 
 instance Storable StgInfoTable where
 

--- a/src/GHC/HeapView/Debug.hs
+++ b/src/GHC/HeapView/Debug.hs
@@ -9,7 +9,6 @@ import System.Mem
 import Data.Maybe
 import Data.Char
 import Data.IORef
-import Control.Applicative ((<$>))
 
 -- | This function walks the heap referenced by the argument, printing the
 -- \"path\", i.e. the pointer indices from the initial to the current closure


### PR DESCRIPTION
This PR allows to compile `ghc-heap-view` with GHC 8.8.1.

As most the GHC version specific code is now used from the `GHC.Exts.Heap` module, future GHC releases will probably only need version number changes in the cabal file.

I also did some cleanup in the `import` statements.

Cabal 3 easily builds and tests this package. However a Travis Configuration with Cabal 3 currently [fails](https://travis-ci.org/hansroland/ghc-heap-view/jobs/594478676) over cabal issue [#5650](https://github.com/haskell/cabal/issues/5650). Therefore I didn't add an explicit test configuration with Cabal 3.
