### PR TITLE
Support GHC-{9.0.1, 9.2.1}

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -32,7 +32,7 @@ main = do
 
     let !(I# m) = length args + 42
     let !(I# m') = length args + 23
-    let f = \ y n -> take (I# m + I# y) n ++ args
+    let f = \ y n -> take (I# m + I# y + 1) n ++ args
     performGC
 
     getClosureData f >>= \ cl -> do

--- a/ghc-heap-view.cabal
+++ b/ghc-heap-view.cabal
@@ -76,7 +76,7 @@ Library
     containers,
     transformers,
     template-haskell,
-    bytestring >= 0.10,
+    bytestring >= 0.10.2,
     binary
   Hs-source-dirs: src/
   Ghc-options: -Wall

--- a/ghc-heap-view.cabal
+++ b/ghc-heap-view.cabal
@@ -41,7 +41,7 @@ Description:
   .
   The work on this package has been supported by the Deutsche Telekom Stiftung
   (<http://telekom-stiftung.de>).
-tested-with: GHC == 8.6.1, GHC == 8.6.2, GHC == 8.6.3, GHC == 8.6.4, GHC == 8.6.5, GHC == 8.8.1, GHC == 8.10.1
+tested-with: GHC == 8.6.1, GHC == 8.6.2, GHC == 8.6.3, GHC == 8.6.4, GHC == 8.6.5, GHC == 8.8.1, GHC == 8.10.1, GHC == 9.0.1, GHC == 9.2.1
 License:             BSD3
 License-file:        LICENSE
 Author:              Joachim Breitner, Dennis Felsing

--- a/ghc-heap-view.cabal
+++ b/ghc-heap-view.cabal
@@ -61,7 +61,7 @@ Flag prim-supports-any
 custom-setup
   setup-depends: base
   setup-depends: filepath
-  setup-depends: Cabal >= 1.24 && < 3.3
+  setup-depends: Cabal >= 1.24 && < 3.7
 
 Library
   Default-Language:    Haskell2010
@@ -71,7 +71,7 @@ Library
     GHC.Disassembler
     GHC.HeapView.Debug
   Build-depends:
-    base >= 4.12 && < 4.15,
+    base >= 4.12 && < 4.17,
     ghc-heap,
     containers,
     transformers,

--- a/src/GHC/Disassembler.hs
+++ b/src/GHC/Disassembler.hs
@@ -7,8 +7,8 @@ module GHC.Disassembler (
 
 import qualified Data.ByteString.Lazy as BS
 import Data.ByteString.Lazy (ByteString)
-import Data.ByteString.Lazy.Builder
-import Data.ByteString.Lazy.Builder.Extras
+import Data.ByteString.Builder
+import Data.ByteString.Builder.Extra
 import Data.Binary.Get
 import Data.Word
 import Data.Int


### PR DESCRIPTION
This adds support for GHC 9.01. and 9.2.1.

A small change needed to be made to the test suite to avoid the newer GHCs inlining a function and changing the shape of the thunk.

Some modules from bytestring had been removed in the package bundled with 9.2.1. 

Instead of adding CPP, I've changed the imports to refer to the new names of the modules, which have been around since bytestring-0.10.2. Given that the earliest GHC in the tested-with field in the cabal file is 8.6.1, which comes bundled with a latter bytestring, afaik this won't break backwards compat with any supported compiler.


Fixes #35 